### PR TITLE
Remove .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 export/
 .vscode/
 art/flashFiles/credits.fla
+.DS_Store


### PR DESCRIPTION
There isn't really any need for this file to be in the git repository - It's only for Mac so Windows and Linux users don't need it - And .DS_Store files are automatically created when a folder is made on Mac.